### PR TITLE
Transfer torch tensors to GPU asynchronously

### DIFF
--- a/gunpowder/torch/nodes/predict.py
+++ b/gunpowder/torch/nodes/predict.py
@@ -156,7 +156,7 @@ class Predict(GenericPredict):
         for array_key, tensor in requested_outputs.items():
             spec = self.spec[array_key].copy()
             spec.roi = request[array_key].roi
-            batch.arrays[array_key] = Array(tensor.cpu().detach().numpy(), spec)
+            batch.arrays[array_key] = Array(tensor.detach().cpu().numpy(), spec)
 
     def stop(self):
         pass

--- a/gunpowder/torch/nodes/predict.py
+++ b/gunpowder/torch/nodes/predict.py
@@ -1,3 +1,4 @@
+import numpy as np
 from gunpowder.array import ArrayKey, Array
 from gunpowder.array_spec import ArraySpec
 from gunpowder.ext import torch
@@ -121,7 +122,8 @@ class Predict(GenericPredict):
 
     def get_inputs(self, batch):
         model_inputs = {
-            key: torch.as_tensor(batch[value].data).to(device=self.device, non_blocking=True)
+            key: torch.as_tensor(np.ascontiguousarray(batch[value].data)).to(
+                device=self.device, non_blocking=True)
             for key, value in self.inputs.items()
         }
         return model_inputs

--- a/gunpowder/torch/nodes/predict.py
+++ b/gunpowder/torch/nodes/predict.py
@@ -121,7 +121,7 @@ class Predict(GenericPredict):
 
     def get_inputs(self, batch):
         model_inputs = {
-            key: torch.as_tensor(batch[value].data, device=self.device)
+            key: torch.as_tensor(batch[value].data).to(device=self.device, non_blocking=True)
             for key, value in self.inputs.items()
         }
         return model_inputs

--- a/gunpowder/torch/nodes/train.py
+++ b/gunpowder/torch/nodes/train.py
@@ -266,7 +266,7 @@ class Train(GenericTrain):
             spec = self.spec[array_key].copy()
             spec.roi = request[array_key].roi
             batch.arrays[array_key] = Array(
-                outputs[array_name].cpu().detach().numpy(), spec
+                outputs[array_name].detach().cpu().numpy(), spec
             )
 
         for array_name, array_key in self.gradients.items():
@@ -283,17 +283,10 @@ class Train(GenericTrain):
             spec = self.spec[array_key].copy()
             spec.roi = request[array_key].roi
             batch.arrays[array_key] = Array(
-                tensor.grad.cpu().detach().numpy(), spec
+                tensor.grad.detach().cpu().numpy(), spec
             )
 
-        for array_key, array_name in requested_outputs.items():
-            spec = self.spec[array_key].copy()
-            spec.roi = request[array_key].roi
-            batch.arrays[array_key] = Array(
-                outputs[array_name].cpu().detach().numpy(), spec
-            )
-
-        batch.loss = loss.cpu().detach().numpy()
+        batch.loss = loss.detach().cpu().numpy()
         self.iteration += 1
         batch.iteration = self.iteration
 

--- a/gunpowder/torch/nodes/train.py
+++ b/gunpowder/torch/nodes/train.py
@@ -201,7 +201,7 @@ class Train(GenericTrain):
 
         # keys are argument names of model forward pass
         device_inputs = {
-            k: torch.as_tensor(v).to(device=self.device, non_blocking=True)
+            k: torch.as_tensor(np.ascontiguousarray(v)).to(device=self.device, non_blocking=True)
             for k, v in inputs.items()
         }
 
@@ -223,7 +223,7 @@ class Train(GenericTrain):
         provided_loss_inputs = self.__collect_provided_loss_inputs(batch)
 
         device_loss_inputs = {
-            k: torch.as_tensor(v).to(device=self.device, non_blocking=True)
+            k: torch.as_tensor(np.ascontiguousarray(v)).to(device=self.device, non_blocking=True)
             for k, v in provided_loss_inputs.items()
         }
 

--- a/gunpowder/torch/nodes/train.py
+++ b/gunpowder/torch/nodes/train.py
@@ -201,7 +201,8 @@ class Train(GenericTrain):
 
         # keys are argument names of model forward pass
         device_inputs = {
-            k: torch.as_tensor(v, device=self.device) for k, v in inputs.items()
+            k: torch.as_tensor(v).to(device=self.device, non_blocking=True)
+            for k, v in inputs.items()
         }
 
         # get outputs. Keys are tuple indices or model attr names as in self.outputs
@@ -222,7 +223,7 @@ class Train(GenericTrain):
         provided_loss_inputs = self.__collect_provided_loss_inputs(batch)
 
         device_loss_inputs = {
-            k: torch.as_tensor(v, device=self.device)
+            k: torch.as_tensor(v).to(device=self.device, non_blocking=True)
             for k, v in provided_loss_inputs.items()
         }
 


### PR DESCRIPTION
Transferring tensors to GPU can be done [asynchronously](https://pytorch.org/docs/stable/tensors.html?highlight=#torch.Tensor.to) with `x.to(device='cuda', non_blocking=True)`. In some cases I observe this to speed up a training pass.

Here I compared the current `gunpowder.torch.Train` transfer calls to the proposed changes in an isolated example, to make sure there is no extra overhead from separating the cast to `torch.tensor` from the transfer to GPU.
```
import time
import torch
import numpy as np

x_np = np.random.rand(128, 128, 128, 128)
n_iter = 10

# init cuda
torch.cuda.set_device(0)
torch.zeros((128, 128, 128, 128), device='cuda')

start = time.time()
for i in range(n_iter):
    x = torch.as_tensor(x_np).to(device='cuda', non_blocking=True)
x_back = x.detach().cpu().numpy()
print(f"Asynchronous: {(time.time() - start) / n_iter} s")

start = time.time()
for i in range(n_iter):
    x = torch.as_tensor(x_np, device='cuda')
x_back = x.detach().cpu().numpy()
print(f"Current gunpowder: {(time.time() - start) / n_iter} s")
```