### PR TITLE
Bug in shift augmentations: Added reproducible test case

### DIFF
--- a/gunpowder/nodes/shift_augment.py
+++ b/gunpowder/nodes/shift_augment.py
@@ -31,6 +31,7 @@ class ShiftAugment(BatchFilter):
 
     def prepare(self, request):
         random.seed(request.random_seed)
+        np.random.seed(request.random_seed)
         
         self.ndim = request.get_total_roi().dims()
         assert self.shift_axis in range(self.ndim)

--- a/tests/cases/shift_augment.py
+++ b/tests/cases/shift_augment.py
@@ -561,6 +561,26 @@ class TestShiftAugment2D(unittest.TestCase):
         result = ShiftAugment.compute_upstream_roi(request_roi, sub_shift_array)
         self.assertTrue(upstream_roi == result)
 
+    #########
+    # DEBUG #
+    #########
+
+    def test_pipeline2__seeded(self):
+
+        key = ArrayKey("TEST_ARRAY")
+        spec = ArraySpec(voxel_size=Coordinate((3, 1)), interpolatable=True)
+
+        hdf5_source = Hdf5Source(
+            self.fake_data_file, {key: "testdata"}, array_specs={key: spec}
+        )
+
+        request = BatchRequest(random_seed=15) # only changed property
+        shape = Coordinate((3, 3))
+        request.add(key, shape, voxel_size=Coordinate((3, 1)))
+
+        shift_node = ShiftAugment(prob_slip=1, prob_shift=1, sigma=1, shift_axis=0)
+        with build((hdf5_source + shift_node)) as b:
+            b.request_batch(request)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cases/shift_augment.py
+++ b/tests/cases/shift_augment.py
@@ -574,11 +574,11 @@ class TestShiftAugment2D(unittest.TestCase):
             self.fake_data_file, {key: "testdata"}, array_specs={key: spec}
         )
 
-        request = BatchRequest(random_seed=15) # only changed property
+        request = BatchRequest(random_seed=19)
         shape = Coordinate((3, 3))
         request.add(key, shape, voxel_size=Coordinate((3, 1)))
 
-        shift_node = ShiftAugment(prob_slip=1, prob_shift=1, sigma=1, shift_axis=0)
+        shift_node = ShiftAugment(prob_slip=0.2, prob_shift=0.2, sigma=1, shift_axis=0)
         with build((hdf5_source + shift_node)) as b:
             b.request_batch(request)
 


### PR DESCRIPTION
Hi,

in some of my unit test runs, the `tests/cases/test_pipeline2` fails:
```
E               AssertionError: Hdf5Source[shift_test.hdf5]: TEST_ARRAY's ROI [0:3, -1:2] (3, 3) outside of my ROI [0:300, 0:100] (300, 100)
E               assert False
E                +  where False = <bound method Roi.contains of [0:300, 0:100] (300, 100)>([0:3, -1:2] (3, 3))
E                +    where <bound method Roi.contains of [0:300, 0:100] (300, 100)> = [0:300, 0:100] (300, 100).contains

```

 The underlying bug is triggered randomly since the `numpy.random` operations in ` ShiftAugment` do not use any seed.

This draft pull request:
- adds a line which seeds `numpy.random` with `request.random_seed`.
- adds a copy of the unit test test_pipeline2` together with a seed which triggers the bug.

I would like to share the test case. For fixing the bug I need more information about the scope of the `ShiftAugment` class ... 
- What would be a setup where a negative offset would be a valid parameter? 
- Do HDF5 files support negative offsets at all?

Pre-Merge Checklist:

- [x] ~if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)~
- [x] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [x] PR branch name is short and describes the feature/bug addressed in this PR
- [x] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [ ] changes reviewed by another contributor
- [x] tests cover changes
- [ ] all tests pass
