### PR TITLE
Update expired dtypes for NumPy 1.24

### DIFF
--- a/docs/tutorial_simple_pipeline.html
+++ b/docs/tutorial_simple_pipeline.html
@@ -677,7 +677,7 @@ deformations, which are provided by the <a class="reference internal" href="api.
 </div>
 <p>We introduced two new concepts in this snippet:</p>
 <p>First, we added a <a class="reference internal" href="api.html#gunpowder.Normalize" title="gunpowder.Normalize"><code class="xref py py-class docutils literal notranslate"><span class="pre">Normalize</span></code></a> node for <code class="docutils literal notranslate"><span class="pre">raw</span></code>. This node ensures that
-the data type of the given array is <code class="docutils literal notranslate"><span class="pre">np.float</span></code> from there on through the
+the data type of the given array is <code class="docutils literal notranslate"><span class="pre">np.float64</span></code> from there on through the
 pipeline. We have so far been agnostic about the exact datatype of <code class="docutils literal notranslate"><span class="pre">raw</span></code> (it
 was <code class="docutils literal notranslate"><span class="pre">uint8</span></code>, by the way). However, in order to shift intensities and to add
 random noise, it is helpful to ensure we are dealing with float values between

--- a/gunpowder/contrib/nodes/add_boundary_distance_gradients.py
+++ b/gunpowder/contrib/nodes/add_boundary_distance_gradients.py
@@ -163,7 +163,7 @@ class AddBoundaryDistanceGradients(BatchFilter):
         out_shape = tuple(2*s - 1 for s in in_shape)
         out_slices = tuple(slice(0, s) for s in out_shape)
 
-        boundaries = np.zeros(out_shape, dtype=np.bool)
+        boundaries = np.zeros(out_shape, dtype=bool)
 
         logger.debug("boundaries shape is %s", boundaries.shape)
 

--- a/gunpowder/morphology.py
+++ b/gunpowder/morphology.py
@@ -100,7 +100,7 @@ def create_ball_kernel(radius, voxel_size):
     voxel_size = np.asarray(voxel_size)
 
     # Calculate shape for new kernel, make it sufficiently large (--> ceil)
-    radius_voxel = np.ceil(radius/voxel_size).astype(np.int)
+    radius_voxel = np.ceil(radius/voxel_size).astype(int)
     kernel_shape = np.array(radius_voxel)*2 + 1
 
     kernel = np.zeros(kernel_shape, dtype=np.uint8)

--- a/gunpowder/nodes/csv_points_source.py
+++ b/gunpowder/nodes/csv_points_source.py
@@ -87,7 +87,7 @@ class CsvPointsSource(BatchProvider):
             "CSV points source got request for %s",
             request[self.points].roi)
 
-        point_filter = np.ones((self.data.shape[0],), dtype=np.bool)
+        point_filter = np.ones((self.data.shape[0],), dtype=bool)
         for d in range(self.ndims):
             point_filter = np.logical_and(point_filter, self.data[:,d] >= min_bb[d])
             point_filter = np.logical_and(point_filter, self.data[:,d] < max_bb[d])

--- a/gunpowder/nodes/dvid_source.py
+++ b/gunpowder/nodes/dvid_source.py
@@ -200,7 +200,6 @@ class DvidSource(BatchProvider):
         if spec.interpolatable is None:
 
             spec.interpolatable = spec.dtype in [
-                np.float,
                 np.float32,
                 np.float64,
                 np.float128,

--- a/gunpowder/nodes/grow_boundary.py
+++ b/gunpowder/nodes/grow_boundary.py
@@ -72,7 +72,7 @@ class GrowBoundary(BatchFilter):
             return
 
         # get all foreground voxels by erosion of each component
-        foreground = np.zeros(shape=gt.shape, dtype=np.bool)
+        foreground = np.zeros(shape=gt.shape, dtype=bool)
         masked = None
         if gt_mask is not None:
             masked = np.equal(gt_mask, 0)

--- a/gunpowder/nodes/hdf5like_source_base.py
+++ b/gunpowder/nodes/hdf5like_source_base.py
@@ -170,7 +170,6 @@ class Hdf5LikeSource(BatchProvider):
 
         if spec.interpolatable is None:
             spec.interpolatable = spec.dtype in [
-                np.float,
                 np.float32,
                 np.float64,
                 np.float128,

--- a/gunpowder/nodes/klb_source.py
+++ b/gunpowder/nodes/klb_source.py
@@ -166,7 +166,6 @@ class KlbSource(BatchProvider):
         if spec.interpolatable is None:
 
             spec.interpolatable = spec.dtype in [
-                np.float,
                 np.float32,
                 np.float64,
                 np.float128,

--- a/gunpowder/nodes/rasterize_graph.py
+++ b/gunpowder/nodes/rasterize_graph.py
@@ -166,9 +166,9 @@ class RasterizeGraph(BatchFilter):
     def prepare(self, request):
 
         if self.settings.mode == 'ball':
-            context = np.ceil(self.settings.radius).astype(np.int)
+            context = np.ceil(self.settings.radius).astype(int)
         elif self.settings.mode == 'peak':
-            context = np.ceil(2*self.settings.radius).astype(np.int)
+            context = np.ceil(2*self.settings.radius).astype(int)
         else:
             raise RuntimeError('unknown raster mode %s'%self.settings.mode)
 


### PR DESCRIPTION
np.bool, np.int and np.float were deprecated in NumPy 1.20, removed in 1.24. This commit replaces them with their built-in aliases so current NumPy versions can be used.

np.bool and np.int are straightforward but np.float can't be simply replaced by float here because it's used in explicit dtype checks. I have removed np.float from these checks instead as np.dtype(float) is equivalent to np.float64, which is already included in the lists.

See:
- https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated
- https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations

Pre-Merge Checklist:

- [ ] if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)
- [x] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [ ] PR branch name is short and describes the feature/bug addressed in this PR
- [ ] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [ ] changes reviewed by another contributor
- [ ] tests cover changes
- [ ] all tests pass
