### PR TITLE
Removed cached hash value

### DIFF
--- a/gunpowder/array.py
+++ b/gunpowder/array.py
@@ -179,7 +179,6 @@ class ArrayKey(Freezable):
 
     def __init__(self, identifier):
         self.identifier = identifier
-        self.hash = hash(identifier)
         self.freeze()
         logger.debug("Registering array key %s", self)
         setattr(ArrayKeys, self.identifier, self)

--- a/gunpowder/array.py
+++ b/gunpowder/array.py
@@ -188,7 +188,7 @@ class ArrayKey(Freezable):
         return hasattr(other, "identifier") and self.identifier == other.identifier
 
     def __hash__(self):
-        return self.hash
+        return hash(self.identifier)
 
     def __repr__(self):
         return self.identifier


### PR DESCRIPTION

This PR removes caching of the hash of `ArrayKey.identifier`. 

I ran into issues when working with gunpowder pipelines in parallel processes. 

The issue occurs when 
(1) parts of the pipeline are initiated in a master process and 
(2) some child process appends to the pipeline with new `ArrayKey`s (but with same identifier as those in the master process). 

`hash(str)` returns a different result for each process in Python.
Thus, the ArrayKey that was initialized in the master process will have a different cached hash value than an ArrayKey initialized in the child process (again, even though they have the same identifier).

Another temporary solution to this is setting the [`PYTHONHASHSEED`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED) environment variable to `0` to disable random seeds in the `hash` function (making `hash(str)` return the same value in master and child process). But this has security implications.

I believe there shouldn't be much of a performance hit by recalculating the hash every time.