### PR TITLE
Stack.py now preserves attrs

### DIFF
--- a/gunpowder/nodes/stack.py
+++ b/gunpowder/nodes/stack.py
@@ -47,7 +47,9 @@ class Stack(BatchFilter):
 
         for key, spec in request.array_specs.items():
             data = np.stack([b[key].data for b in batches])
+            attrs = [b[key].attrs for b in batches]
             batch[key] = Array(data, batches[0][key].spec.copy())
+            batch[key].attrs = attrs
 
         # copy points of first batch requested
         for key, spec in request.graph_specs.items():


### PR DESCRIPTION
took me a while to figure out why my attrs data (initially found from using extra_data in SpecifiedLocation) was not preserved at end of pipeline. This was it.

Pre-Merge Checklist:

- [ ] if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)
- [X ] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [ ] PR branch name is short and describes the feature/bug addressed in this PR
- [ ] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [ ] changes reviewed by another contributor
- [ ] tests cover changes
- [ ] all tests pass
