### PR TITLE
Bug patch 1.4.4 - dependency management

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -7,11 +7,9 @@ jobs:
     name: Python Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
       - name: Setup checkout
         uses: actions/checkout@master
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Lint with Black
-        run: |
-          pip install black
-          black --check gunpowder tests
+        run: uv run --extra dev black --check gunpowder tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .[dev]
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Run tests
-        run: pytest -v --color yes --cov gunpowder --cov-report xml
+        run: uv run --python=${{ matrix.python-version }} --extra dev pytest -v --color yes --cov gunpowder --cov-report xml
 
       - uses: codecov/codecov-action@v3

--- a/gunpowder/contrib/nodes/add_blobs_from_points.py
+++ b/gunpowder/contrib/nodes/add_blobs_from_points.py
@@ -102,11 +102,8 @@ class AddBlobsFromPoints(BatchFilter):
                     ].roi.union(request_roi)
             else:
                 # do nothing if no blobs of this type were requested
-                logger.warning(
-                    "%s output array type for %s never requested. \
-                    Deleting entry..."
-                    % (settings["output_array_key"], blob_name)
-                )
+                logger.warning("%s output array type for %s never requested. \
+                    Deleting entry..." % (settings["output_array_key"], blob_name))
                 del self.blob_settings[blob_name]
 
     def process(self, batch, request):
@@ -122,14 +119,12 @@ class AddBlobsFromPoints(BatchFilter):
             # Make sure both the necesary point types and arrays are present
             assert points_key in batch.points, (
                 "Upstream does not provide required point type\
-            : %s"
-                % points_key
+            : %s" % points_key
             )
 
             assert restrictive_mask_key in batch.arrays, (
                 "Upstream does not provide required \
-            array type: %s"
-                % restrictive_mask_key
+            array type: %s" % restrictive_mask_key
             )
 
             # Get point data

--- a/gunpowder/contrib/nodes/add_nonsymmetric_affinities.py
+++ b/gunpowder/contrib/nodes/add_nonsymmetric_affinities.py
@@ -24,16 +24,10 @@ class AddNonsymmetricAffinities(BatchFilter):
         self.affinity_vectors = affinity_vectors
 
     def setup(self):
-        assert self.array_key_1 in self.spec, (
-            "Upstream does not provide %s needed by \
-        AddNonsymmetricAffinities"
-            % self.array_key_1
-        )
-        assert self.array_key_2 in self.spec, (
-            "Upstream does not provide %s needed by \
-        AddNonsymmetricAffinities"
-            % self.array_key_2
-        )
+        assert self.array_key_1 in self.spec, "Upstream does not provide %s needed by \
+        AddNonsymmetricAffinities" % self.array_key_1
+        assert self.array_key_2 in self.spec, "Upstream does not provide %s needed by \
+        AddNonsymmetricAffinities" % self.array_key_2
 
         voxel_size = self.spec[self.array_key_1].voxel_size
 

--- a/gunpowder/version_info.py
+++ b/gunpowder/version_info.py
@@ -1,6 +1,6 @@
 __major__ = 1
 __minor__ = 4
-__patch__ = 3
+__patch__ = 4
 __tag__ = ""
 __version__ = "{}.{}.{}{}".format(__major__, __minor__, __patch__, __tag__).strip(".")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "augment-nd>=0.1.3",
     "tqdm",
     "funlib.geometry>=0.3",
-    "zarr",
+    "zarr>=2,<3",
     "networkx>=3.1",
     "funlib.persistence>=0.5,<=0.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "mypy",
     "types-requests",
     "types-tqdm",
-    "black>=25,<=26",
+    "black>=26",
     "ruff",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = ["version"]
 
 classifiers = ["Programming Language :: Python :: 3"]
 keywords = []
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "numpy>=1.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "mypy",
     "types-requests",
     "types-tqdm",
-    "black",
+    "black>=25,<=26",
     "ruff",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "funlib.geometry>=0.3",
     "zarr",
     "networkx>=3.1",
-    "funlib.persistence>=0.5",
+    "funlib.persistence>=0.5,<=0.6",
 ]
 
 [project.optional-dependencies]

--- a/tests/cases/tensorflow_train.py
+++ b/tests/cases/tensorflow_train.py
@@ -103,7 +103,7 @@ def test_output(tmpdir):
     a_grad_key = ArrayKey("GRADIENT_A")
 
     # create model meta graph file and get input/output names
-    (a, b, c, optimizer, loss) = create_meta_graph(meta_base)
+    a, b, c, optimizer, loss = create_meta_graph(meta_base)
 
     source = ExampleTensorflowTrainSource()
     train = Train(


### PR DESCRIPTION
Pre-Merge Checklist:

- [ ] if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)
- [ ] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [x] PR branch name is short and describes the feature/bug addressed in this PR
- [ ] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [ ] changes reviewed by another contributor
- [x] tests cover changes
- [x] all tests pass

Mostly just pinning dependencies a bit more strictly. Some of our dependencies have released new versions that break gunpowder.
- zarr 3 breaks n5 support
- python 3.9 wasn't tested and was broken. Pinned minimum python version to 3.10
- black 25 formats differently than black 26. Pinned to 26 which is compatible now that we dropped python 3.9 support
- pin funlib.persistence to versions 0.5 and 0.6. 0.7 uses zarr3 and breaks n5 support

Also formatted with the new black version to pass that github action.

Also updated some workflows to use `uv` to manage dependencies